### PR TITLE
Use per-instance directory for all QEMU runtime files

### DIFF
--- a/example/cmd/root.go
+++ b/example/cmd/root.go
@@ -25,7 +25,19 @@ var rootCmd = &cobra.Command{
 			return platformErr
 		}
 
-		instance, instanceErr := qemu.Start("example", image, "out", "err", qemu.Config{
+		// Create instance directory with image
+		dir, dirErr := os.MkdirTemp("", "qemu-example-*")
+		if dirErr != nil {
+			return dirErr
+		}
+		defer os.RemoveAll(dir)
+
+		// Copy/link image into instance dir
+		if linkErr := os.Symlink(image, qemu.ImagePath(dir)); linkErr != nil {
+			return linkErr
+		}
+
+		instance, instanceErr := qemu.Start("example", dir, qemu.Config{
 			Cpus:     1,
 			Memory:   1024,      // 1 GB
 			Disk:     40 * 1024, // 40 GB
@@ -53,11 +65,6 @@ chpasswd:
 		if instanceErr != nil {
 			return instanceErr
 		}
-
-		defer func() {
-			_ = os.Remove("out")
-			_ = os.Remove("err")
-		}()
 
 		go func() {
 			time.Sleep(5 * time.Second) // Wait for the VM to start

--- a/pkg/qemu/args.go
+++ b/pkg/qemu/args.go
@@ -30,12 +30,9 @@ type QemuConfig struct {
 	Accelerator string
 	Network     NetworkConfig
 	Platform    *PlatformConfig
-	Qmp         string
-	Qga         string
-	Image       string
+	Dir         string // instance directory — all runtime paths derived from this
 	CloudInit   CloudInitConfig
 	Hardware    Hardware
-	TmpDir      string
 	Bios        string
 }
 
@@ -71,21 +68,9 @@ func Platform(platform *PlatformConfig) Option {
 	}
 }
 
-func Qmp(path string) Option {
+func Dir(path string) Option {
 	return func(config *QemuConfig) {
-		config.Qmp = path
-	}
-}
-
-func Qga(path string) Option {
-	return func(config *QemuConfig) {
-		config.Qga = path
-	}
-}
-
-func Image(path string) Option {
-	return func(config *QemuConfig) {
-		config.Image = path
+		config.Dir = path
 	}
 }
 
@@ -113,12 +98,6 @@ func Cpus(cpus int) Option {
 	}
 }
 
-func TmpDir(path string) Option {
-	return func(config *QemuConfig) {
-		config.TmpDir = path
-	}
-}
-
 func Bios(bios string) Option {
 	return func(config *QemuConfig) {
 		config.Bios = bios
@@ -142,8 +121,13 @@ func BuildQemuArgs(opts ...Option) ([]string, error) {
 		opt(config)
 	}
 
+	imagePath := ImagePath(config.Dir)
+	qmpPath := QmpSocketPath(config.Dir)
+	qgaPath := QgaSocketPath(config.Dir)
+	pidfilePath := PidfilePath(config.Dir)
+
 	image := utils.Image{
-		Path: config.Image,
+		Path: imagePath,
 	}
 
 	if info, infoErr := image.Info(); infoErr == nil {
@@ -169,20 +153,21 @@ func BuildQemuArgs(opts ...Option) ([]string, error) {
 	}
 	args = append(args, netArgs...)
 
-	args = append(args, "-qmp", fmt.Sprintf("unix:%s,server,wait=off", config.Qmp))
+	args = append(args, "-qmp", fmt.Sprintf("unix:%s,server,wait=off", qmpPath))
 	args = append(args, "-cpu", "host")
 	args = append(args, "-smp", fmt.Sprintf("%d", config.Hardware.Cpus))
-	args = append(args, "-hda", config.Image)
+	args = append(args, "-hda", imagePath)
+	args = append(args, "-pidfile", pidfilePath)
 	args = append(args, "-device", "virtio-serial")
-	args = append(args, "-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=charchannel0", config.Qga))
+	args = append(args, "-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=charchannel0", qgaPath))
 	args = append(args, "-device", "virtserialport,chardev=charchannel0,name=org.qemu.guest_agent.0")
 
-	tmpDir, tmpDirErr := os.MkdirTemp("", "cloudinit-*")
-	if tmpDirErr != nil {
-		return nil, tmpDirErr
+	cloudInitDir := CloudInitPath(config.Dir)
+	if mkdirErr := os.MkdirAll(cloudInitDir, 0755); mkdirErr != nil {
+		return nil, mkdirErr
 	}
 
-	cloudInitPath, cloudInitErr := utils.CreateCloudInitISO(config.CloudInit.Userdata, config.CloudInit.NetworkConfig, tmpDir, config.Id)
+	cloudInitPath, cloudInitErr := utils.CreateCloudInitISO(config.CloudInit.Userdata, config.CloudInit.NetworkConfig, cloudInitDir, config.Id)
 	if cloudInitErr != nil {
 		return nil, cloudInitErr
 	}

--- a/pkg/qemu/instance.go
+++ b/pkg/qemu/instance.go
@@ -5,6 +5,9 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -27,15 +30,57 @@ type Config struct {
 	CloudInit CloudInitConfig
 }
 
-func qmpSocketFor(name string) string {
-	return fmt.Sprintf("/tmp/%s.sock", name)
+// Path helpers — all runtime files live inside the instance directory.
+
+func QmpSocketPath(dir string) string {
+	return filepath.Join(dir, "qmp.sock")
 }
 
-func qgaSocketFor(name string) string {
-	return fmt.Sprintf("/tmp/qga-%s.sock", name)
+func QgaSocketPath(dir string) string {
+	return filepath.Join(dir, "qga.sock")
 }
 
-func Attach(name string, pid int) (*Instance, error) {
+func PidfilePath(dir string) string {
+	return filepath.Join(dir, "pid")
+}
+
+func StdoutPath(dir string) string {
+	return filepath.Join(dir, "stdout")
+}
+
+func StderrPath(dir string) string {
+	return filepath.Join(dir, "stderr")
+}
+
+func ImagePath(dir string) string {
+	return filepath.Join(dir, "image")
+}
+
+func CloudInitPath(dir string) string {
+	return filepath.Join(dir, "cloudinit")
+}
+
+func ReadPidfile(dir string) (int, error) {
+	data, err := os.ReadFile(PidfilePath(dir))
+	if err != nil {
+		return 0, err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, fmt.Errorf("invalid pidfile content: %w", err)
+	}
+	return pid, nil
+}
+
+func ProcessAlive(pid int) bool {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+func Attach(name, dir string, pid int) (*Instance, error) {
 	proc, procErr := os.FindProcess(pid)
 	if procErr != nil {
 		return nil, procErr
@@ -53,19 +98,17 @@ func Attach(name string, pid int) (*Instance, error) {
 			}
 			time.Sleep(100 * time.Millisecond)
 		}
-		os.Remove(qmpSocketFor(name))
-		os.Remove(qgaSocketFor(name))
 	}()
 
 	return &Instance{
-		QMP:  qmpSocketFor(name),
-		QGA:  qgaSocketFor(name),
+		QMP:  QmpSocketPath(dir),
+		QGA:  QgaSocketPath(dir),
 		Pid:  pid,
 		Done: ch,
 	}, nil
 }
 
-func Start(name, url, outFilePath, errFilePath string, config Config) (*Instance, error) {
+func Start(name, dir string, config Config) (*Instance, error) {
 	qemuBinary, qemuBinaryErr := utils.GetQemuBinary()
 	if qemuBinaryErr != nil {
 		return nil, qemuBinaryErr
@@ -73,11 +116,6 @@ func Start(name, url, outFilePath, errFilePath string, config Config) (*Instance
 
 	if _, err := exec.LookPath(qemuBinary); err != nil {
 		return nil, fmt.Errorf("%s is not available; please install %s", qemuBinary, qemuBinary)
-	}
-
-	tmpDir, tmpDirErr := os.MkdirTemp("", "cloudinit-*")
-	if tmpDirErr != nil {
-		return nil, tmpDirErr
 	}
 
 	machineType, machineTypeErr := utils.GetMachineType()
@@ -102,32 +140,28 @@ func Start(name, url, outFilePath, errFilePath string, config Config) (*Instance
 			Driver: "virtio-net",
 		}),
 		Platform(config.Platform),
-		Image(url),
+		Dir(dir),
 		CloudInit(config.CloudInit),
-		TmpDir(tmpDir),
 		Bios(bios),
-		Qmp(qmpSocketFor(name)),
-		Qga(qgaSocketFor(name)),
 	)
 	if argsErr != nil {
 		return nil, argsErr
 	}
 
 	// Remove stale socket files from a previous run before starting QEMU.
-	// QEMU creates these as server sockets; if stale files remain, the new
-	// instance may fail to bind or clients may get "connection refused".
-	os.Remove(qmpSocketFor(name))
-	os.Remove(qgaSocketFor(name))
+	os.Remove(QmpSocketPath(dir))
+	os.Remove(QgaSocketPath(dir))
 
 	slog.Info("QEMU command", "binary", qemuBinary, "args", args)
 	command := exec.Command(qemuBinary, args...)
-	outFile, outFileErr := os.OpenFile(outFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+
+	outFile, outFileErr := os.OpenFile(StdoutPath(dir), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
 	if outFileErr != nil {
 		return nil, outFileErr
 	}
 	command.Stdout = outFile
 
-	errFile, errFileErr := os.OpenFile(errFilePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	errFile, errFileErr := os.OpenFile(StderrPath(dir), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
 	if errFileErr != nil {
 		return nil, errFileErr
 	}
@@ -146,22 +180,19 @@ func Start(name, url, outFilePath, errFilePath string, config Config) (*Instance
 
 	ch := make(chan interface{})
 
-	go func(name string) {
-		defer os.RemoveAll(tmpDir)
+	go func() {
 		defer close(ch)
 
 		waitErr := command.Wait()
 		if waitErr != nil {
 			slog.Info("Exited with error", "error", waitErr)
 		}
-		os.Remove(qmpSocketFor(name))
-		os.Remove(qgaSocketFor(name))
 		ch <- true
-	}(name)
+	}()
 
 	return &Instance{
-		QMP:  qmpSocketFor(name),
-		QGA:  qgaSocketFor(name),
+		QMP:  QmpSocketPath(dir),
+		QGA:  QgaSocketPath(dir),
 		Pid:  command.Process.Pid,
 		Done: ch,
 	}, nil


### PR DESCRIPTION
Replace individual path parameters (qmp, qga, image, stdout, stderr) with a single instance directory. All runtime files — disk image, QMP/QGA sockets, pidfile, logs, and cloud-init ISO — are now derived from the directory path, making instance lifecycle and cleanup self-contained.