### PR TITLE
Load image using virtio blk driver

### DIFF
--- a/pkg/qemu/args.go
+++ b/pkg/qemu/args.go
@@ -175,7 +175,11 @@ func BuildQemuArgs(opts ...Option) ([]string, error) {
 	}
 	args = append(args, "-cpu", cpuModel)
 	args = append(args, "-smp", strconv.Itoa(config.Hardware.Cpus))
-	args = append(args, "-hda", imagePath)
+	// Attach the OS image over virtio-blk so it comes up as the primary
+	// disk (vda). The Ubuntu generic cloud image boots "initrdless": it
+	// ships no initramfs and relies on GRUB_FORCE_PARTUUID plus drivers
+	// built into the kernel.
+	args = append(args, "-drive", fmt.Sprintf("file=%s,if=virtio,format=qcow2", imagePath))
 	args = append(args, "-pidfile", pidfilePath)
 	args = append(args, "-device", "virtio-serial")
 	args = append(args, "-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=charchannel0", qgaPath))


### PR DESCRIPTION
The OS image was attached via -hda (q35 AHCI/SATA). Resolute generic cloud images boot initrdless and have no AHCI driver built in (CONFIG_SATA_AHCI=m, no initramfs), so root=PARTUUID was unresolvable and the guest panicked. virtio-blk is built in, so it boots with no initramfs. Worked on noble only because it shipped a fallback initramfs.